### PR TITLE
Remove leading slashes from asset paths

### DIFF
--- a/modules/page-transitions/module.php
+++ b/modules/page-transitions/module.php
@@ -822,7 +822,7 @@ class Module extends Module_Base {
 
 		wp_enqueue_script(
 			'instant-page',
-			ELEMENTOR_PRO_ASSETS_URL . "/lib/instant-page/instant-page{$suffix}.js",
+			ELEMENTOR_PRO_ASSETS_URL . "lib/instant-page/instant-page{$suffix}.js",
 			null,
 			ELEMENTOR_PRO_VERSION,
 			true

--- a/modules/screenshots/render-mode-screenshot.php
+++ b/modules/screenshots/render-mode-screenshot.php
@@ -41,7 +41,7 @@ class Render_Mode_Screenshot extends Render_Mode_Base {
 
 		wp_enqueue_script(
 			'dom-to-image',
-			ELEMENTOR_PRO_ASSETS_URL . "/lib/dom-to-image/js/dom-to-image{$suffix}.js",
+			ELEMENTOR_PRO_ASSETS_URL . "lib/dom-to-image/js/dom-to-image{$suffix}.js",
 			[],
 			'2.6.0',
 			true
@@ -49,7 +49,7 @@ class Render_Mode_Screenshot extends Render_Mode_Base {
 
 		wp_enqueue_script(
 			'html2canvas',
-			ELEMENTOR_PRO_ASSETS_URL . "/lib/html2canvas/js/html2canvas{$suffix}.js",
+			ELEMENTOR_PRO_ASSETS_URL . "lib/html2canvas/js/html2canvas{$suffix}.js",
 			[],
 			'1.0.0-rc.5',
 			true
@@ -57,7 +57,7 @@ class Render_Mode_Screenshot extends Render_Mode_Base {
 
 		wp_enqueue_script(
 			'elementor-screenshot',
-			ELEMENTOR_PRO_ASSETS_URL . "/js/screenshot{$suffix}.js",
+			ELEMENTOR_PRO_ASSETS_URL . "js/screenshot{$suffix}.js",
 			[ 'dom-to-image', 'html2canvas' ],
 			ELEMENTOR_PRO_VERSION,
 			true


### PR DESCRIPTION
The trailing slash is already included on the definiton of the `ELEMENTOR_PRO_ASSETS_URL` constant which results in the compiled URL having a double slash. This is fine in environments like Apache where double slashes are normalised, but for environments which don't tolerate that (e.g. S3) it causes the asset to 404.