### PR TITLE
Fix error in woocomerce with columns is 0

### DIFF
--- a/modules/woocommerce/module.php
+++ b/modules/woocommerce/module.php
@@ -1598,11 +1598,10 @@ class Module extends Module_Base {
 		$settings = array_merge( $settings, $query_settings );
 
 		if ( isset( $settings['posts_per_page'], $settings['columns']) && is_numeric($settings['posts_per_page']) && is_numeric($settings['columns'])) {
-    		if ((int)$settings['columns'] > 0) {  
+    		if ((int)$settings['columns'] > 0)
         		$settings['rows'] = ceil($settings['posts_per_page'] / $settings['columns']);
-    		} else {
-                $settings['rows'] = 1;  
-    		}
+    		else
+                $settings['rows'] = 1;
 		}
 
 		$settings['paginate'] = 'yes';

--- a/modules/woocommerce/module.php
+++ b/modules/woocommerce/module.php
@@ -1597,9 +1597,6 @@ class Module extends Module_Base {
 
 		$settings = array_merge( $settings, $query_settings );
 
-		if ( isset( $settings['posts_per_page'] ) && isset( $settings['columns'] ) ) {
-			$settings['rows'] = ceil( $settings['posts_per_page'] / $settings['columns'] );
-		}
 		if ( isset( $settings['posts_per_page'], $settings['columns']) && is_numeric($settings['posts_per_page']) && is_numeric($settings['columns'])) {
     		if ((int)$settings['columns'] > 0) {  
         		$settings['rows'] = ceil($settings['posts_per_page'] / $settings['columns']);

--- a/modules/woocommerce/module.php
+++ b/modules/woocommerce/module.php
@@ -1600,6 +1600,13 @@ class Module extends Module_Base {
 		if ( isset( $settings['posts_per_page'] ) && isset( $settings['columns'] ) ) {
 			$settings['rows'] = ceil( $settings['posts_per_page'] / $settings['columns'] );
 		}
+		if ( isset( $settings['posts_per_page'], $settings['columns']) && is_numeric($settings['posts_per_page']) && is_numeric($settings['columns'])) {
+    		if ((int)$settings['columns'] > 0) {  
+        		$settings['rows'] = ceil($settings['posts_per_page'] / $settings['columns']);
+    		} else {
+                $settings['rows'] = 1;  
+    		}
+		}
 
 		$settings['paginate'] = 'yes';
 		$settings['allow_order'] = 'no';


### PR DESCRIPTION
Prevent an error in woocommerce when columns is 0.