### PR TITLE
The way proelements calls the textdomain it is not compatible with wp 6.7 and above.  Please change the code

### DIFF
--- a/pro-elements.php
+++ b/pro-elements.php
@@ -14,18 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-
-function pro_elements_plugin_load_plugin() {
-	if ( ! did_action( 'elementor/loaded' ) ) {
-		add_action( 'admin_notices', 'pro_elements_plugin_fail_load' );
-
-		return;
-	}
-	if ( defined( 'ELEMENTOR_PRO_VERSION' ) ) {
-		return;
-	}
-
-	define( 'ELEMENTOR_PRO_VERSION', '3.25.2' );
+define( 'ELEMENTOR_PRO_VERSION', '3.25.3' );
 
 /**
  * All versions should be `major.minor`, without patch, in order to compare them properly.
@@ -44,9 +33,15 @@ define( 'ELEMENTOR_PRO_MODULES_PATH', ELEMENTOR_PRO_PATH . 'modules/' );
 define( 'ELEMENTOR_PRO_URL', plugins_url( '/', ELEMENTOR_PRO__FILE__ ) );
 define( 'ELEMENTOR_PRO_ASSETS_URL', ELEMENTOR_PRO_URL . 'assets/' );
 define( 'ELEMENTOR_PRO_MODULES_URL', ELEMENTOR_PRO_URL . 'modules/' );
-	define( 'IS_PRO_ELEMENTS', 'true' );
-	add_action( 'plugins_loaded', 'pro_elements_load_plugin_func' );
+define( 'IS_PRO_ELEMENTS', 'true' );
+// Include Composer's autoloader
+if ( file_exists( ELEMENTOR_PRO_PATH . 'vendor/autoload.php' ) ) {
+	require_once ELEMENTOR_PRO_PATH . 'vendor/autoload.php';
+	// We need this file because of the DI\create function that we are using.
+	// Autoload classmap doesn't include this file.
+	require_once ELEMENTOR_PRO_PATH . 'vendor_prefixed/php-di/php-di/src/functions.php';
 }
+
 
 
 
@@ -59,6 +54,16 @@ define( 'ELEMENTOR_PRO_MODULES_URL', ELEMENTOR_PRO_URL . 'modules/' );
  */
 function pro_elements_load_plugin_func() {
 	load_plugin_textdomain( 'elementor-pro' );
+
+	if ( ! did_action( 'elementor/loaded' ) ) {
+		add_action( 'admin_notices', 'elementor_pro_fail_load' );
+
+		return;
+	}
+
+	if ( defined( 'ELEMENTOR_PRO_VERSION' ) ) {
+		return;
+	}
 
 	$core_version = ELEMENTOR_VERSION;
 	$core_version_required = ELEMENTOR_PRO_REQUIRED_CORE_VERSION;
@@ -74,14 +79,6 @@ function pro_elements_load_plugin_func() {
 		add_action( 'admin_notices', 'pro_elements_admin_notice_upgrade_recommendation' );
 	}
 
-	// Include Composer's autoloader
-	if ( file_exists( ELEMENTOR_PRO_PATH . 'vendor/autoload.php' ) ) {
-		require_once ELEMENTOR_PRO_PATH . 'vendor/autoload.php';
-		// We need this file because of the DI\create function that we are using.
-		// Autoload classmap doesn't include this file.
-		require_once ELEMENTOR_PRO_PATH . 'vendor_prefixed/php-di/php-di/src/functions.php';
-	}
-
 	require ELEMENTOR_PRO_PATH . 'plugin.php';
 }
 
@@ -95,7 +92,7 @@ function pro_elements_compare_major_version( $left, $right, $operator ) {
 	return version_compare( $left, $right, $operator );
 }
 
-pro_elements_plugin_load_plugin();
+add_action( 'plugins_loaded', 'pro_elements_load_plugin_func' );
 
 function pro_elements_print_error( $message ) {
 	if ( ! $message ) {

--- a/pro-elements.php
+++ b/pro-elements.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-define( 'ELEMENTOR_PRO_VERSION', '3.25.3' );
+define( 'ELEMENTOR_PRO_VERSION', '3.25.2' );
 
 /**
  * All versions should be `major.minor`, without patch, in order to compare them properly.
@@ -34,16 +34,6 @@ define( 'ELEMENTOR_PRO_URL', plugins_url( '/', ELEMENTOR_PRO__FILE__ ) );
 define( 'ELEMENTOR_PRO_ASSETS_URL', ELEMENTOR_PRO_URL . 'assets/' );
 define( 'ELEMENTOR_PRO_MODULES_URL', ELEMENTOR_PRO_URL . 'modules/' );
 define( 'IS_PRO_ELEMENTS', 'true' );
-// Include Composer's autoloader
-if ( file_exists( ELEMENTOR_PRO_PATH . 'vendor/autoload.php' ) ) {
-	require_once ELEMENTOR_PRO_PATH . 'vendor/autoload.php';
-	// We need this file because of the DI\create function that we are using.
-	// Autoload classmap doesn't include this file.
-	require_once ELEMENTOR_PRO_PATH . 'vendor_prefixed/php-di/php-di/src/functions.php';
-}
-
-
-
 
 /**
  * Load gettext translate for our text domain.
@@ -78,7 +68,13 @@ function pro_elements_load_plugin_func() {
 	if ( ! pro_elements_compare_major_version( $core_version, $core_version_recommended, '>=' ) ) {
 		add_action( 'admin_notices', 'pro_elements_admin_notice_upgrade_recommendation' );
 	}
-
+	// Include Composer's autoloader
+	if ( file_exists( ELEMENTOR_PRO_PATH . 'vendor/autoload.php' ) ) {
+		require_once ELEMENTOR_PRO_PATH . 'vendor/autoload.php';
+		// We need this file because of the DI\create function that we are using.
+		// Autoload classmap doesn't include this file.
+		require_once ELEMENTOR_PRO_PATH . 'vendor_prefixed/php-di/php-di/src/functions.php';
+	}
 	require ELEMENTOR_PRO_PATH . 'plugin.php';
 }
 


### PR DESCRIPTION
Not compatible with wp 6.7  Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the elementor-pro domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This message was added in version 6.7.0.) in /home/public_html/wp-includes/functions.php on line 6114