### PR TITLE
L10n error "running too early"

### DIFF
--- a/license.txt
+++ b/license.txt
@@ -1,5 +1,5 @@
 Copyright (C) 2016-2024 Elementor Ltd. <https://elementor.com>.
-Modifications Copyright (C) 2020 PROElements.org <https://proelements.org>.
+Modifications Copyright (C) 2020-2025 PROElements.org <https://proelements.org>.
 
 The code in this folder is a derivative work of the code from the Elementor Pro by Elementor Ltd., which is licensed under GPLv3. This code, therefore, is also licensed under the terms of the GNU Public License, version 3.
 


### PR DESCRIPTION
"Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the woocommerce domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This message was added in version 6.7.0.) in /var/www/vhosts/***/httpdocs/gh/wp-includes/functions.php on line 6114"
See also https://wordpress.org/support/topic/pro-elements-plugin-is-giving-error/