### PR TITLE
Fix PHP warnings: check array before accessing offsets in updater.php

### DIFF
--- a/updater/updater.php
+++ b/updater/updater.php
@@ -103,21 +103,25 @@ class Updater {
 			$this->config['description'] = $this->get_description();
 
 		$plugin_data = $this->get_plugin_data();
-		if ( ! isset( $this->config['plugin_name'] ) )
-			$this->config['plugin_name'] = $plugin_data['Name'];
 
-		if ( ! isset( $this->config['version'] ) )
-			$this->config['version'] = $plugin_data['Version'];
+        if (!empty($plugin_data)) {
 
-		if ( ! isset( $this->config['author'] ) )
-			$this->config['author'] = $plugin_data['Author'];
+            if ( ! isset( $this->config['plugin_name'] ) )
+                $this->config['plugin_name'] = $plugin_data['Name'];
 
-		if ( ! isset( $this->config['homepage'] ) )
-			$this->config['homepage'] = $plugin_data['PluginURI'];
+            if ( ! isset( $this->config['version'] ) )
+                $this->config['version'] = $plugin_data['Version'];
 
-		if ( ! isset( $this->config['readme'] ) )
-			$this->config['readme'] = 'README.md';
+            if ( ! isset( $this->config['author'] ) )
+                $this->config['author'] = $plugin_data['Author'];
 
+            if ( ! isset( $this->config['homepage'] ) )
+                $this->config['homepage'] = $plugin_data['PluginURI'];
+
+            if ( ! isset( $this->config['readme'] ) )
+                $this->config['readme'] = 'README.md';
+
+	    }
 	}
 
 


### PR DESCRIPTION
This PR removes PHP warnings caused by trying to access array offsets on boolean false in updater.php lines 116-125. 

The fix adds an if (!empty($plugin_data)) condition before accessing any keys in $plugin_data