### PR TITLE
Bump version to 4.0.4.1 in pro-elements.php to avoid wrong install of pro elements 4.0.4 causing fatal error

### DIFF
--- a/pro-elements.php
+++ b/pro-elements.php
@@ -3,7 +3,7 @@
  * Plugin Name: PRO Elements
  * Description: Adds professional features for sites using the Elementor page builder.
  * Plugin URI: https://proelements.org/
- * Version: 4.0.4
+ * Version: 4.0.4.1
  * Author: PROElements.org
  * Author URI: https://proelements.org/
  * Requires PHP: 7.4
@@ -28,7 +28,7 @@ function pro_elements_plugin_load_plugin() {
 		return;
 	}
 
-	define( 'ELEMENTOR_PRO_VERSION', '4.0.4' );
+	define( 'ELEMENTOR_PRO_VERSION', '4.0.4.1' );
 
 /**
  * All versions should be `major.minor`, without patch, in order to compare them properly.


### PR DESCRIPTION
Bumb version number to install the correct pro elements to avoid fatal error as the updater is still installing the wrong pro elements 4..04