### PR TITLE
CI: fail the release when the tag doesn't match the plugin version in pro-elements.php

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Verify plugin version matches tag
+      shell: bash
+      run: |
+        TAG="${GITHUB_REF_NAME#v}"
+        HEADER_VERSION="$(grep -m1 -oP '^\s*\*\s*Version:\s*\K[0-9][0-9a-zA-Z.\-]*' pro-elements.php)"
+        CONSTANT_VERSION="$(grep -m1 -oP "define\(\s*'ELEMENTOR_PRO_VERSION',\s*'\K[^']+" pro-elements.php)"
+        echo "Tag: ${TAG} | Version header: ${HEADER_VERSION} | ELEMENTOR_PRO_VERSION: ${CONSTANT_VERSION}"
+        if [ "${HEADER_VERSION}" != "${TAG}" ] || [ "${CONSTANT_VERSION}" != "${TAG}" ]; then
+          echo "::error file=pro-elements.php::Tag ${TAG} does not match pro-elements.php (Version header: ${HEADER_VERSION}, ELEMENTOR_PRO_VERSION: ${CONSTANT_VERSION}). Publishing a mismatched zip leaves users with a permanent update nag."
+          exit 1
+        fi
     - name: Build
       shell: bash
       run: git archive --format=zip --prefix="pro-elements/" HEAD > pro-elements.zip


### PR DESCRIPTION
## What

Adds a verification step to the release workflow that fails the publish if the pushed git tag doesn't match both version declarations in `pro-elements.php` (the `Version:` plugin header and the `ELEMENTOR_PRO_VERSION` constant).

## Why

The v4.0.4.1 release was tagged and published while `pro-elements.php` inside the zip still said `Version: 4.0.4` / `ELEMENTOR_PRO_VERSION = '4.0.4'`. When that happens:

1. **Permanent update nag:** after installing the release, WordPress still reports the installed version as `4.0.4`, so the `4.0.4.1` update is offered forever — reinstalling never resolves it. Users have to manually edit the version header to escape the loop. (v4.0.4.2 shipped correct, so nothing is currently broken — this is purely process hardening.)
2. **wp-admin Plugins screen fatal:** while the mismatched update is pending, Elementor's compatibility-tag module parses the four-segment `new_version` with `Elementor\Core\Utils\Version::create_from_string()`, which throws an uncaught exception for versions with more than three segments — a recovery-mode WSOD on the Plugins screen. We hit this in production; I've also submitted the Elementor-side fix (elementor/elementor#36451), but preventing mismatched releases here protects users on all existing Elementor versions.

## How it works

Before building the zip, the workflow strips the `v` prefix from the tag and compares it against both declarations extracted from `pro-elements.php`. On mismatch it prints an actionable error annotation and exits 1, so the release asset is never uploaded. Verified the two `grep` extraction patterns against the current `pro-elements.php` (both yield `4.1.0`, matching tag `v4.1.0`).

Example failure output for a v4.0.4.1-style mismatch:

```
Tag: 4.0.4.1 | Version header: 4.0.4 | ELEMENTOR_PRO_VERSION: 4.0.4
Error: Tag 4.0.4.1 does not match pro-elements.php (Version header: 4.0.4, ELEMENTOR_PRO_VERSION: 4.0.4). Publishing a mismatched zip leaves users with a permanent update nag.
```

Thanks for maintaining Pro Elements — we run it in production, and this was the only operational issue we've had with it.
