### PR TITLE
Fix posts_per_page argument to be absint

### DIFF
--- a/modules/woocommerce/widgets/product-related.php
+++ b/modules/woocommerce/widgets/product-related.php
@@ -250,7 +250,7 @@ class Product_Related extends Products_Base {
 		$args = array_map( 'sanitize_text_field', $args );
 
 		// Get visible related products then sort them at random.
-		$args['related_products'] = array_filter( array_map( 'wc_get_product', wc_get_related_products( $product->get_id(), $args['posts_per_page'], $product->get_upsell_ids() ) ), 'wc_products_array_filter_visible' );
+		$args['related_products'] = array_filter( array_map( 'wc_get_product', wc_get_related_products( $product->get_id(), absint( $args['posts_per_page'] ), $product->get_upsell_ids() ) ), 'wc_products_array_filter_visible' );
 
 		// Handle orderby.
 		$args['related_products'] = wc_products_array_orderby( $args['related_products'], $args['orderby'], $args['order'] );


### PR DESCRIPTION
### Fix: Cast `posts_per_page` to integer in Product Related widget

**Description:**
`$args['posts_per_page']` is sanitized via `sanitize_text_field()` prior to querying related products, converting the value to a string (e.g., `"4"`). This triggers a WooCommerce warning/error log: `Invalid limit type passed to wc_get_related_products. Expected integer, got string`.

**Solution:**
Wrapped `$args['posts_per_page']` with `absint()` when passing it to `wc_get_related_products()` to ensure strict type compliance.